### PR TITLE
SSL doesn't work.

### DIFF
--- a/icb/server.c
+++ b/icb/server.c
@@ -9,6 +9,7 @@
 #include <limits.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
+#include <fcntl.h>
 
 #include <arpa/inet.h>
 #include <netdb.h>


### PR DESCRIPTION
I'm writing my own ICB server at the moment. I noticed that cicb doesn't handle SSL properly. This pull request should fix the issues :)

1. select() can't be used to test for incoming data because openssl has its own state. The new code uses SSL_peek() instead.
2. SSL_peek() will block forever if O_NONBLOCKING isn't set. I had to include fcntl.h in server.c to make it work.
3. readpacket() tries now to read all remaining bytes if SSL is on.

I have a test server on internetcitizens.band. It supports SSL and Non-SSL connections.

Thanks for your great work!

Sebastian